### PR TITLE
Fixed bug which prevented multiple select fields from being saved

### DIFF
--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -3,14 +3,14 @@
 Plugin Name: PMPro Register Helper
 Plugin URI: http://www.paidmembershipspro.com/pmpro-register-helper/
 Description: Shortcodes and other functions to help customize your registration forms.
-Version: .5.19
+Version: .5.20
 Author: Stranger Studios
 Author URI: http://www.strangerstudios.com
 */
 
 define('PMPRORH_DIR', dirname(__FILE__) );
 define('PMPRORH_URL', WP_PLUGIN_URL . "/pmpro-register-helper");
-define('PMPRORH_VERSION', '.5.19');
+define('PMPRORH_VERSION', '.5.20');
 
 /*
 	options - just defaults for now, will be in settings eventually
@@ -422,7 +422,7 @@ function pmprorh_pmpro_after_checkout($user_id)
 				elseif(isset($_SESSION[$field->name]))
 				{					
 					//file or value?
-					if(is_array($_SESSION[$field->name]))
+					if(is_array($_SESSION[$field->name]) && isset($_SESSION[$field->name]['name']))
 					{
 						//add to files global
 						$_FILES[$field->name] = $_SESSION[$field->name];

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: strangerstudios
 Tags: users, user meta, meta, memberships, registration
 Requires at least: 3.5
 Tested up to: 4.0.1
-Stable tag: .5.19
+Stable tag: .5.20
 
 Add extra fields to your checkout page. Works with Paid Memberships Pro.
 
@@ -109,6 +109,9 @@ Note that the "checkout_boxes" location is now just the first checkout_box in th
 Please post it in the issues section of GitHub and we'll fix it as soon as we can. Thanks for helping. https://github.com/strangerstudios/pmpro-register-helper/issues
 
 == Changelog ==
+= .5.20 =
+* Fixed bug which prevented multiple select fields user metadata from being saved when getting back from payment gateway.
+
 = .5.19 =
 * Can now set the "showrequired" option to "label" (all lower) and the required asterisk will be rendered between the label and the input field. Useful for some themes/designs.
 * Fixed warning in pmprorh_cron_delete_tmp(). (Thanks, nozzljohn)


### PR DESCRIPTION
When getting back from payment, user registration fields are retrived from `$_SESSION` data and saved.

I found that that **multiple choices fields** are processed as they were **file fields** preventing the former from being correctly saved in user metadata.

```php
[multiple-choice-field] => Array
    (
        [0] => selected-chioce-1
        [1] => selected-chioce-2
        [2] => selected-chioce-3
    )

[file-field] => Array
	(
	    [name] => foo.jpg
	    [type] => image/jpeg
	    [tmp_name] => path/to/file.tmp
	    [error] => 0
	    [size] => 32121
	)
```
In order to fix it I added a condition to the `if` expression which evaluate whether the field is an image. If $_SESSION field array has a the **'name' key** it's processed as a file, otherwise data is saved as it is.