### PR TITLE
Field displays in spite of $field->levels setting

### DIFF
--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -1039,7 +1039,7 @@ function pmprorh_checkFieldForLevel($field, $scope = "default", $args = NULL)
 			{
 				if(is_array($field->levels) && in_array($_REQUEST['level'], $field->levels))
 					return true;
-				elseif(intval($_REQUEST['level']) == intval($field->levels))
+				elseif(!is_array($field->levels) && (intval($_REQUEST['level']) == intval($field->levels)))
 					return true;
 				else
 					return false;


### PR DESCRIPTION
Reported in http://www.paidmembershipspro.com/forums/topic/custom-field-register-helper-bug-using-levels/#post-50062

"NO matter what this field would show up for my level 1 registrations which as you can see is not listed in the “levels” array for the field. Only levels (5,6,7,8) should receive this new field."