### PR TITLE
pmpro_signup uses blogname for default title

### DIFF
--- a/shortcodes/pmpro_signup.php
+++ b/shortcodes/pmpro_signup.php
@@ -25,7 +25,7 @@ function pmprorh_signup_shortcode($atts, $content=null, $code="")
 	), $atts));
 	
 	// set title
-	if (empty($title))
+	if (isset($title))
 		if(!empty($level))
 			$title = 'Register For ' . pmpro_getLevel($level)->name;
 		else

--- a/shortcodes/pmpro_signup.php
+++ b/shortcodes/pmpro_signup.php
@@ -14,12 +14,6 @@ function pmprorh_signup_shortcode($atts, $content=null, $code="")
 	if(!function_exists('pmpro_getLevel'))
 		return "Paid Memberships Pro must be installed to use the pmpro_signup shortcode.";
 
-	//default title
-	if(!empty($level))
-		$default_title = 'Register For ' . pmpro_getLevel($level)->name;
-	else
-		$default_title = 'Register For ' . get_option('blogname');
-
 	//set defaults
 	extract(shortcode_atts(array(
 		'button' => "Sign Up Now",
@@ -27,9 +21,17 @@ function pmprorh_signup_shortcode($atts, $content=null, $code="")
 		'level' => NULL,
 		'login' => true,
 		'short' => NULL,
-		'title' => $default_title,
+		'title' => NULL,
 	), $atts));
-
+	
+	// set title
+	if (empty($title))
+		if(!empty($level))
+			$title = 'Register For ' . pmpro_getLevel($level)->name;
+		else
+			
+			$title = 'Register For ' . get_option('blogname');
+	
 	//turn 0's into falses
 	if($login === "0" || $login === "false" || $login === "no")
 		$login = false;


### PR DESCRIPTION
Because of the location of the $level test to use the level's title, the pmpro_signup shortcode would always use the blog name rather than the level name as the title unless the admin specified the (optional) 'title' attribute.

Moving the $title & $level check to after the attributes have been processed fixes this issue.