### PR TITLE
Using unsupported HTML attribute for <select>

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -301,11 +301,11 @@
 				if(!is_array($value))
 					$value = array($value);
 				
-				$r = '<select id="' . $this->id . '" name="' . $this->name . '[]" multiple="multiple"';
+				$r = '<select id="' . $this->id . '" name="' . $this->name . '[]" multiple="multiple" ';
 				if(!empty($this->class))
 					$r .= 'class="' . $this->class . '" ';
 				if(!empty($this->readonly))
-					$r .= 'readonly="readonly" ';
+					$r .= 'disabled="disabled" ';
 				$r .= ">\n";
 				foreach($this->options as $ovalue => $option)
 				{
@@ -327,7 +327,7 @@
 				if(!empty($this->class))
 					$r .= 'class="' . $this->class . '" ';
 				if(!empty($this->readonly))
-					$r .= 'readonly="readonly" ';
+					$r .= 'disabled="disabled" ';
 				$r .= '>';
 				foreach($this->options as $ovalue => $option)
 				{


### PR DESCRIPTION
When the readonly attribute is set for a <select> field (type => 'select|multiselect'), we attempted to use the 'readonly="readonly"' attribute in the <select></select> tag. This attribute is not supported by the <select> HTML tag. Instead, we should use 'disabled="disabled"'.