### PR TITLE
FIX: PHP Warning if no pmprorh_add_checkbox_box()

### DIFF
--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -664,8 +664,12 @@ function pmprorh_rf_show_extra_profile_fields($user, $withlocations = false)
 		foreach($profile_fields as $where => $fields)
 		{						
 			$box = pmprorh_getCheckoutBoxByName($where);			
-			?>
-			<h3><?php echo $box->label;?></h3>
+			
+			if ( !empty($box->label) ) 
+			{ ?>
+				<h3><?php echo $box->label; ?></h3><?php
+			} ?>
+			
 			<table class="form-table">
 			<?php
 			//cycle through groups			


### PR DESCRIPTION
If the user forgets/omits to include a call to `pmpro_rh_add_checkbox()` while configuring the RH fields, a PHP Warning will get thrown.