### PR TITLE
Only include register helper's select2.css/js on the frontend

### DIFF
--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -1103,8 +1103,11 @@ function pmproh_pmpro_checkout_confirm_email($show)
 function pmprorh_enqueue_select2()
 {
 	//should check for cases when this is needed instead of always including.
-	wp_enqueue_style('select2', plugins_url('css/select2.css', __FILE__), '', '3.1', 'screen');
-	wp_enqueue_script('select2', plugins_url('js/select2.js', __FILE__), array( 'jquery' ), '3.1' );
+	// only inlcude on frontend
+	if( !is_admin() ) {
+		wp_enqueue_style('select2', plugins_url('css/select2.css', __FILE__), '', '3.1', 'screen');
+		wp_enqueue_script('select2', plugins_url('js/select2.js', __FILE__), array( 'jquery' ), '3.1' );
+	}
 }
 add_action("init", "pmprorh_enqueue_select2");
 


### PR DESCRIPTION
This is interfering with a number of other plugin's select boxes. Additionally Wordpress already has select2 dashboard styles/functionality.