### PR TITLE
Fix after_email checkout hook

### DIFF
--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -311,7 +311,7 @@ function pmprorh_pmpro_checkout_after_email()
 	{
 		foreach($pmprorh_registration_fields["after_email"] as $field)
 		{			
-			if(pmprorh_checkFieldForLevel($field) && isset($field->profile) && $field->profile !== "only" && $field->profile !== "only_admin")
+			if(pmprorh_checkFieldForLevel($field) && $field->profile !== "only" && $field->profile !== "only_admin")
 				$field->displayAtCheckout();		
 		}
 	}


### PR DESCRIPTION
Checking for `isset` was causing the `after_email` hook to break for me, and it wouldn't show any fields hooked into it.