### PR TITLE
BUG: JavaScript error if RH dependency is defined

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -589,7 +589,7 @@
 					{
 						$checks[] = "((jQuery('#" . $check['id']."')".".is(':checkbox')) "
 						 ."? jQuery('#" . $check['id'] . ":checked').length > 1"
-						 .":(jQuery('#" . $check['id'] . "').val() == " . json_encode($check['value']) . " || jQuery.inArray(" . json_encode($check['value']) . ", jQuery('#" . $check['id'] . "').val()) > -1)) ||"."(jQuery(\"input:radio[name='".$check['id']."']:checked\").val() == '".json_encode($check['value'])."' || jQuery.inArray('".json_encode($check['value'])."', jQuery(\"input:radio[name='".$check['id']."']:checked\").val()) > -1)";
+						 .":(jQuery('#" . $check['id'] . "').val() == " . json_encode($check['value']) . " || jQuery.inArray(" . json_encode($check['value']) . ", jQuery('#" . $check['id'] . "').val()) > -1)) ||"."(jQuery(\"input:radio[name='".$check['id']."']:checked\").val() == ".json_encode($check['value'])." || jQuery.inArray(".json_encode($check['value']).", jQuery(\"input:radio[name='".$check['id']."']:checked\").val()) > -1)";
 					
 						$binds[] = "#" . $check['id'].",input:radio[name=".$check['id']."]";
 					}				


### PR DESCRIPTION
The introduction of `json_encode()` in commit #175e239 breaks JavaScript on checkout.php if there is one or more Register Helper fields with dependencies, and those dependencies contain quote characters. `json_encode()` will correctly code strings anyway, so shouldn't need to include single-quotes to wrap the `json_encode()` calls