### PR TITLE
Update register helper to show a pre-completed date field correctly.

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -638,7 +638,25 @@
 			global $current_user;
 			
 			//value passed yet?
-			if(isset($_REQUEST[$this->name]))
+			if($this->type == "date") {
+				if(isset($_REQUEST[$this->name."[m]"])) {
+					$tempstr = $_REQUEST[$this->name."[m]"]." ";
+					$tempstr .= intval($_REQUEST[$this->name."[d]"]).", ";
+					$tempstr .= intval($_REQUEST[$this->name."[y]"]);
+					$value = $tempstr; // will be modified by strtotime later.
+				} elseif(isset($_SESSION[$this->name."[m]"])) {
+					$tempstr = $_SESSION[$this->name."[m]"]." ";
+					$tempstr .= intval($_SESSION[$this->name."[d]"]).", ";
+					$tempstr .= intval($_SESSION[$this->name."[y]"]);
+					$value = $tempstr; // will be modified by strtotime later.
+				} elseif(!empty($current_user->ID) && metadata_exists("user", $current_user->ID, $this->meta_key)) {
+					$meta = get_user_meta($current_user->ID, $this->meta_key, true);
+					$value = $meta;
+				} elseif(!empty($this->value))
+					$value = $this->value;
+				else
+					$value = "";
+			} elseif(isset($_REQUEST[$this->name]))
 				$value = $_REQUEST[$this->name];
 			elseif(isset($_SESSION[$this->name]))
 			{


### PR DESCRIPTION
Previously, re-display of a form with a date field wouldn’t keep the
user’s settings. Now, it should.