### PR TITLE
BUG FIX: strtotime() fix.

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -503,9 +503,9 @@
 
                 //setup date vars
                 if(!empty($value))
-                    $value = strtotime($value);
-                else
-                    $value = strtotime(date('Y-m-d'));
+		    $value = strtotime(implode("-", $value), current_time('timestamp'));
+		else
+        	    $value = strtotime(date('Y-m-d'), current_time('timestamp'));
 
                 $year = date("Y", $value);
                 $month = date("n", $value);

--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -503,7 +503,7 @@
 
                 //setup date vars
                 if(!empty($value))
-		    $value = strtotime(implode("-", $value), current_time('timestamp'));
+		    $value = strtotime(implode("/", $value), current_time('timestamp'));
 		else
         	    $value = strtotime(date('Y-m-d'), current_time('timestamp'));
 

--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -502,10 +502,13 @@
                 $r .= ' >';
 
                 //setup date vars
-                if(!empty($value))
+                if(is_array($value) && !empty($value)){
 		    $value = strtotime(implode("/", $value), current_time('timestamp'));
-		else
-        	    $value = strtotime(date('Y-m-d'), current_time('timestamp'));
+		}elseif(!is_array($value) && !empty($value)){
+		    $value = strtotime($value, current_time('timestamp'));
+		}else{
+		    $value = strtotime(date('Y-m-d'), current_time('timestamp'));
+		}
 
                 $year = date("Y", $value);
                 $month = date("n", $value);


### PR DESCRIPTION
BUG FIX: strtotime() expects parameter 1 to be string, array given

Above error was shown when a required field was left blank. Imploded the array to fix the issue.
