### PR TITLE
BUG FIX: Required File Upload not recognized

### DIFF
--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -618,7 +618,7 @@ function pmprorh_rf_pmpro_registration_checks($okay)
 				else
 					$value = false;
 			 
-				if(!empty($field->required) && empty( $_REQUEST[$field->name] ) && empty( $_FILES[$field->name] ) )
+				if(!empty($field->required) && empty( $_REQUEST[$field->name] ) && empty( $_FILES[$field->name]['name'] ) )
 				{
 					$required[] = $field->name;
                     $required_labels[] = $field->label;

--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -618,7 +618,7 @@ function pmprorh_rf_pmpro_registration_checks($okay)
 				else
 					$value = false;
 			 
-				if(!empty($field->required) && !isset( $_REQUEST[$field->name] ) )
+				if(!empty($field->required) && !isset( $_REQUEST[$field->name] ) && !isset( $_FILES[$field->name] ) )
 				{
 					$required[] = $field->name;
                     $required_labels[] = $field->label;
@@ -870,9 +870,11 @@ function pmprorh_pmpro_add_member_added( $uid = null, $user = null )
 	            if ( isset( $field->sanitize ) && true === $field->sanitize ) {
 
 		            $value = pmprorh_sanitize( $_POST[ $field->name ] );
-	            } else {
+	            } elseif( isset($_POST[$field->name]) ) {
 	                $value = $_POST[ $field->name ];
-                }
+                    } else {
+                        $value = $_FILES[$field->name];
+                    }
 
                 //callback?
                 if(!empty($field->save_function))
@@ -996,9 +998,11 @@ function pmprorh_rf_save_extra_profile_fields( $user_id )
 				if ( isset( $field->sanitize ) && true === $field->sanitize ) {
 
 					$value = pmprorh_sanitize( $_POST[ $field->name ] );
-				} else {
-				    $value = $_POST[ $field->name ];
-                }
+				} elseif( isset($_POST[$field->name]) ) {
+	                		$value = $_POST[ $field->name ];
+                		} else {
+                    			$value = $_FILES[$field->name];
+                		}
 
 				//callback?
 				if(!empty($field->save_function))

--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -618,7 +618,7 @@ function pmprorh_rf_pmpro_registration_checks($okay)
 				else
 					$value = false;
 			 
-				if(!empty($field->required) && empty( $_REQUEST[$field->name] ) && empty( $_FILES[$field->name]['name'] ) )
+				if(!empty($field->required) && empty( $_REQUEST[$field->name] ) && ( empty( $_FILES[$field->name]['name'] ) && empty( $_REQUEST[$field->name.'_old'] ) ) )
 				{
 					$required[] = $field->name;
                     $required_labels[] = $field->label;

--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -618,7 +618,7 @@ function pmprorh_rf_pmpro_registration_checks($okay)
 				else
 					$value = false;
 			 
-				if(!empty($field->required) && !isset( $_REQUEST[$field->name] ) && !isset( $_FILES[$field->name] ) )
+				if(!empty($field->required) && empty( $_REQUEST[$field->name] ) && empty( $_FILES[$field->name] ) )
 				{
 					$required[] = $field->name;
                     $required_labels[] = $field->label;


### PR DESCRIPTION
File Upload fields that were required failed to be recognized after 1.3.5 update
Also added $value = $_FILES[$field->name]; where needed. 
Additional edits to $value may be needed if sanitize is defaulted to true on File Uploads.