### PR TITLE
BUG FIX: 0 is a valid value for a select drop-down

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -332,7 +332,7 @@
 					$r .= '<option value="' . esc_attr($ovalue) . '" ';
 					if(!empty($this->multiple) && in_array($ovalue, $value))
 						$r .= 'selected="selected" ';
-					elseif(!empty($ovalue) && $ovalue == $value)
+					elseif($ovalue == $value)
 						$r .= 'selected="selected" ';
 					$r .= '>' . $option . "</option>\n";
 				}
@@ -355,7 +355,7 @@
 				foreach($this->options as $ovalue => $option)
 				{
 					$r .= '<option value="' . esc_attr($ovalue) . '" ';
-					if(!empty($ovalue) && in_array($ovalue, $value))
+					if(in_array($ovalue, $value))
 						$r .= 'selected="selected" ';
 					$r .= '>' . $option . "</option>\n";
 				}
@@ -379,7 +379,7 @@
 				foreach($this->options as $ovalue => $option)
 				{
 					$r .= '<option value="' . esc_attr($ovalue) . '" ';
-					if(!empty($ovalue) && in_array($ovalue, $value))
+					if(in_array($ovalue, $value))
 						$r .= 'selected="selected" ';
 					$r .= '>' . $option . '</option>';
 				}


### PR DESCRIPTION
Using `empty()` meant any saved RH field value of 0 would cause the select/multiselect/select2 fields to not select the 0 based key entry