### PR TITLE
Add missing space after select2 placeholder

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -371,7 +371,7 @@
 					$value = array($value);
 					
 				//build multi select
-				$r = '<select id="' . $this->id . '" name="' . $this->name . '[]" multiple="multiple" placeholder='.__('"Choose one or more."', 'pmpro-register-helper');
+				$r = '<select id="' . $this->id . '" name="' . $this->name . '[]" multiple="multiple" placeholder='.__('"Choose one or more." ', 'pmpro-register-helper');
 				if(!empty($this->class))
 					$r .= 'class="' . $this->class . '" ';
 				if(!empty($this->readonly))


### PR DESCRIPTION
select2 placeholder attribute has no space after closing double quotation mark resulting in no spacing between placeholder and class HTML attributes 
e.g. classplaceholder="Choose one or more."class="input " instead of placeholder="Choose one or more." class="input "