### PR TITLE
Let missing required fields be unrequired

### DIFF
--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -634,6 +634,7 @@ function pmprorh_rf_pmpro_registration_checks($okay)
 				}
 				else{
 					$value = false;
+					continue;
 				}
 
 				if(!empty($field->required) && empty( $_REQUEST[$field->name] ) && empty( $_FILES[$field->name]['name'] ) && empty( $_REQUEST[$field->name.'_old'] ) )

--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -632,13 +632,14 @@ function pmprorh_rf_pmpro_registration_checks($okay)
 						}
 					}
 				}
-				else
+				else{
 					$value = false;
+				}
 
 				if(!empty($field->required) && empty( $_REQUEST[$field->name] ) && empty( $_FILES[$field->name]['name'] ) && empty( $_REQUEST[$field->name.'_old'] ) )
 				{
 					$required[] = $field->name;
-                    $required_labels[] = $field->label;
+					$required_labels[] = $field->label;
 				}
 			}
 		}


### PR DESCRIPTION
Fields absent on page are still required when Submit button is clicked.

**Steps to Reproduce**
- Create a Membership Level
- Create a registration field and make it required
- Add the field to a position before "AFTER BILLING FIELDS"
- Change membership level
- Submit form

**Issue**
The form will not be submitted because the absent field is still required.

**Sample Code**

```
 function my_pmprorh_init()
{
	//don't break if Register Helper is not loaded
	if(!function_exists( 'pmprorh_add_registration_field' )) {
		return false;
	}
	
	//define the fields
	$fields = array();
	$fields[] = new PMProRH_Field(
		'first_name',						// input name, will also be used as meta key
		'text',							// type of field
		array(
			'label' => 'First Name',
			'profile' => true,		
			'required' => true
		)
	);
	
	//add the fields into a new checkout_boxes are of the checkout page
	foreach($fields as $field)
			pmprorh_add_registration_field(
			'checkout_boxes',				// location on checkout page
			$field						// PMProRH_Field object
		);
}

add_action( 'init', 'my_pmprorh_init' );
```