### PR TITLE
Users table fields editing via RH using the pmprorh_user_table_fields filter; Checkout box description to Member Profile Edit page; File field type deletion and previews.

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -135,6 +135,14 @@
 			}	
 			elseif($this->type == "file")
 			{
+				// Default to file preview if image type.
+				if ( ! isset( $this->preview ) ) {
+					$this->preview = true;
+				}
+				// Default to allow file delete if full source known.
+				if ( ! isset( $this->allow_delete ) ) {
+					$this->allow_delete = true;
+				}
 				//use the file save function
 				$this->save_function = array($this, "saveFile");
 			}
@@ -177,12 +185,32 @@
 			$user = get_userdata($user_id);
 			$meta_key = str_replace("pmprorhprefix_", "", $name);
 
+			// deleting?
+			if( isset( $_REQUEST['pmprorh_delete_file_' . $name . '_field'] ) ) {
+				$delete_old_file_name = $_REQUEST['pmprorh_delete_file_' . $name . '_field'];
+				if ( ! empty( $delete_old_file_name ) ) {
+					$old_file_meta = get_user_meta( $user->ID, $meta_key, true );					
+					if ( 
+						! empty( $old_file_meta ) && 
+						! empty( $old_file_meta['fullpath'] ) && 
+						file_exists( $old_file_meta['fullpath'] ) &&
+						$old_file_meta['filename'] ==  $delete_old_file_name
+					) {				
+						unlink( $old_file_meta['fullpath'] );
+						unlink( $old_file_meta['previewpath'] );
+						delete_user_meta( $user->ID, $meta_key );
+					}
+				}
+			}
+
 			//no file?
-			if(empty($file['name']))
+			if(empty($file['name'])) {
 				return;
-			
+			}
+
 			//check extension against allowed extensions
-			$filetype = wp_check_filetype_and_ext($file['tmp_name'], $file['name']);									
+			$filetype = wp_check_filetype_and_ext($file['tmp_name'], $file['name']);
+
 			if((!$filetype['type'] || !$filetype['ext'] ) && !current_user_can( 'unfiltered_upload' ))
 			{			
 				//we throw an error earlier, but this just bails on the upload just in case
@@ -240,10 +268,10 @@
 			}
 						
 			//if we already have a file for this field, delete it
-			$old_file = get_user_meta($user->ID, $meta_key, true);			
+			$old_file = get_user_meta($user->ID, $meta_key, true);
 			if(!empty($old_file) && !empty($old_file['fullpath']) && file_exists($old_file['fullpath']))
 			{				
-				unlink($old_file['fullpath']);				
+				unlink($old_file['fullpath']);
 			}
 			
 			//figure out new filename
@@ -276,8 +304,31 @@
 				move_uploaded_file($file['tmp_name'], $pmprorh_dir . $filename);				
 			}
 			
+			// If file is an image, save a preview thumbnail.
+			if ( $filetype && 0 === strpos( $filetype['type'], 'image/' ) ) {
+				$preview_file = wp_get_image_editor( $pmprorh_dir . $filename );
+				if ( ! is_wp_error( $preview_file ) ) {
+					$preview_file->resize( 200, NULL, false );
+					$preview_file->generate_filename( 'pmprorh_preview' );
+					$preview_file = $preview_file->save();
+				}
+			}
+
+			$file_meta_value_array = array(
+				'original_filename'	=> $file['name'],
+				'filename'			=> $filename,
+				'fullpath'			=> $pmprorh_dir . $filename,
+				'fullurl'			=> content_url('/uploads/pmpro-register-helper/' . $user->user_login . '/' . $filename),
+				'size'				=> $file['size'],
+			);
+
+			if ( ! empty( $preview_file ) && ! is_wp_error( $preview_file ) ) {
+				$file_meta_value_array['previewpath'] = $preview_file['path'];
+				$file_meta_value_array['previewurl'] = content_url('/uploads/pmpro-register-helper/' . $user->user_login . '/' . $preview_file['file'] );
+			}
+
 			//save filename in usermeta
-			update_user_meta($user_id, $meta_key, array("original_filename"=>$file['name'], "filename"=>$filename, "fullpath"=> $pmprorh_dir . $filename, "fullurl"=>content_url("/uploads/pmpro-register-helper/" . $user->user_login . "/" . $filename), "size"=>$file['size']));			
+			update_user_meta($user_id, $meta_key, $file_meta_value_array );			
 		}
 
         //fix date then update user meta
@@ -556,8 +607,10 @@
 					$r .= 'class="' . $this->class . '" ';
 				if(!empty($this->html_attributes))
 					$r .= $this->getHTMLAttributes();
-				$r .= 'name="' . $this->name . '" />';								
-				
+				if(!empty($this->readonly))
+					$r .= 'disabled="disabled" ';
+				$r .= 'name="' . $this->name . '" />';
+
 				//old value
 				if(is_user_logged_in())
 				{
@@ -566,24 +619,50 @@
 					if(!empty($old_value))
 						$r .= '<input type="hidden" name="' . $this->name . '_old" value="' . esc_attr($old_value['filename']) . '" />';
 				}
-				
+
+				// Show a preview of existing file if image type.
+				if ( ( ! isset( $this->preview ) || ! empty( $this->preview ) ) && ! empty( $value ) && ! empty( $this->file['previewurl'] ) ) {
+					$filetype = wp_check_filetype( basename( $this->file['previewurl'] ), null );
+					if ( $filetype && 0 === strpos( $filetype['type'], 'image/' ) ) {
+						$r_end .= '<div class="pmprorh_file_preview"><img src="' . $this->file['previewurl'] . '" alt="' . basename($value) . '" /></div>';
+					}
+				}
+
 				//show name of existing file
 				if(!empty($value))
 				{
 					if(!empty($this->file['fullurl']))
-						$r_end .= '<small class="lite">Current File: <a target="_blank" href="' . $this->file['fullurl'] . '">' . basename($value) . '</a></small>';
+						$r_end .= '<span class="pmprorh_file_' . $this->name . '_name">Current File: <a target="_blank" href="' . $this->file['fullurl'] . '">' . basename($value) . '</a></span>';
 					else
-						$r_end .= '<small class="lite">Current File: ' . basename($value) . '</small>';
+						$r_end .= 'Current File: ' . basename($value);
+
+					// Allow user to delete the uploaded file if we know the full location. 
+					if ( ( ! isset( $this->allow_delete ) || ! empty( $this->allow_delete ) ) && ! empty( $this->file['fullurl'] ) ) {
+						$r_end .= '&nbsp;&nbsp;<button class="pmprorh_delete_restore_file" id="pmprorh_delete_file_' . $this->name . '_button" onclick="return false;">' . __( '[delete]', 'pmpro-register-helper' ) . '</button>';
+						$r_end .= '<button class="pmprorh_delete_restore_file" id="pmprorh_cancel_delete_file_' . $this->name . '_button" style="display: none;" onclick="return false;">' . __( '[restore]', 'pmpro-register-helper' ) . '</button>';
+						$r_end .= '<input id="pmprorh_delete_file_' . $this->name . '_field" name="pmprorh_delete_file_' . $this->name . '_field" type="hidden" value="0" />';
+					}
 				}
-			
-				if(!empty($this->readonly))
-					$r .= 'readonly="readonly" ';
 				
-				//include script to change enctype of the form
+				//include script to change enctype of the form and allow deletion
 				$r .= '
 				<script>
 					jQuery(document).ready(function() {
 						jQuery("#' . $this->id . '").closest("form").attr("enctype", "multipart/form-data");
+
+						jQuery("#pmprorh_delete_file_' . $this->name . '_button").click(function(){
+							jQuery("#pmprorh_delete_file_' . $this->name . '_field").val("' . basename($value) . '");
+							jQuery(".pmprorh_file_' . $this->name . '_name").css("text-decoration", "line-through");
+							jQuery("#pmprorh_cancel_delete_file_' . $this->name . '_button").show();
+							jQuery("#pmprorh_delete_file_' . $this->name . '_button").hide();
+						});
+
+						jQuery("#pmprorh_cancel_delete_file_' . $this->name . '_button").click(function(){
+							jQuery("#pmprorh_delete_file_' . $this->name . '_field").val(0);
+							jQuery(".pmprorh_file_' . $this->name . '_name").css("text-decoration", "none");
+							jQuery("#pmprorh_delete_file_' . $this->name . '_button").show();
+							jQuery("#pmprorh_cancel_delete_file_' . $this->name . '_button").hide();
+						});
 					});
 				</script>
 				';

--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -141,7 +141,7 @@
 				}
 				// Default to allow file delete if full source known.
 				if ( ! isset( $this->allow_delete ) ) {
-					$this->allow_delete = true;
+					$this->allow_delete = 'only_admin';
 				}
 				//use the file save function
 				$this->save_function = array($this, "saveFile");
@@ -197,7 +197,9 @@
 						$old_file_meta['filename'] ==  $delete_old_file_name
 					) {				
 						unlink( $old_file_meta['fullpath'] );
-						unlink( $old_file_meta['previewpath'] );
+						if ( ! empty( $old_file_meta['previewpath'] ) ) {
+							unlink( $old_file_meta['previewpath'] );
+						}
 						delete_user_meta( $user->ID, $meta_key );
 					}
 				}
@@ -621,7 +623,7 @@
 				}
 
 				// Show a preview of existing file if image type.
-				if ( ( ! isset( $this->preview ) || ! empty( $this->preview ) ) && ! empty( $value ) && ! empty( $this->file['previewurl'] ) ) {
+				if ( ( ! empty( $this->preview ) ) && ! empty( $value ) && ! empty( $this->file['previewurl'] ) ) {
 					$filetype = wp_check_filetype( basename( $this->file['previewurl'] ), null );
 					if ( $filetype && 0 === strpos( $filetype['type'], 'image/' ) ) {
 						$r_end .= '<div class="pmprorh_file_preview"><img src="' . $this->file['previewurl'] . '" alt="' . basename($value) . '" /></div>';
@@ -632,15 +634,20 @@
 				if(!empty($value))
 				{
 					if(!empty($this->file['fullurl']))
-						$r_end .= '<span class="pmprorh_file_' . $this->name . '_name">Current File: <a target="_blank" href="' . $this->file['fullurl'] . '">' . basename($value) . '</a></span>';
+						$r_end .= '<span class="pmprorh_file_' . $this->name . '_name">' . sprintf(__('Current File: %s', 'pmpro-register-helper' ), '<a target="_blank" href="' . $this->file['fullurl'] . '">' . basename($value) . '</a>' ) . '</span>';
 					else
-						$r_end .= 'Current File: ' . basename($value);
+						$r_end .= sprintf(__('Current File: %s', 'pmpro-register-helper' ), basename($value) );
 
 					// Allow user to delete the uploaded file if we know the full location. 
-					if ( ( ! isset( $this->allow_delete ) || ! empty( $this->allow_delete ) ) && ! empty( $this->file['fullurl'] ) ) {
-						$r_end .= '&nbsp;&nbsp;<button class="pmprorh_delete_restore_file" id="pmprorh_delete_file_' . $this->name . '_button" onclick="return false;">' . __( '[delete]', 'pmpro-register-helper' ) . '</button>';
+					if ( ( ! empty( $this->allow_delete ) ) && ! empty( $this->file['fullurl'] ) ) {
+						// Check whether the current user can delete the uploaded file based on the field attribute 'allow_delete'.
+						if ( $this->allow_delete === true || 
+							( $this->allow_delete === 'admins' || $this->allow_delete === 'only_admin' && current_user_can( 'manage_options', $current_user->ID ) )
+						) {
+ 						$r_end .= '&nbsp;&nbsp;<button class="pmprorh_delete_restore_file" id="pmprorh_delete_file_' . $this->name . '_button" onclick="return false;">' . __( '[delete]', 'pmpro-register-helper' ) . '</button>';
 						$r_end .= '<button class="pmprorh_delete_restore_file" id="pmprorh_cancel_delete_file_' . $this->name . '_button" style="display: none;" onclick="return false;">' . __( '[restore]', 'pmpro-register-helper' ) . '</button>';
 						$r_end .= '<input id="pmprorh_delete_file_' . $this->name . '_field" name="pmprorh_delete_file_' . $this->name . '_field" type="hidden" value="0" />';
+						}
 					}
 				}
 				

--- a/css/pmprorh_admin.css
+++ b/css/pmprorh_admin.css
@@ -1,0 +1,9 @@
+/* Admin CSS for Register Helper */
+div.pmprorh_file_preview {
+	display: block;
+	margin: 1em 0 0 0;
+}
+div.pmprorh_file_preview img {
+	max-height: 150px;
+	max-width: 150px;
+}

--- a/css/pmprorh_frontend.css
+++ b/css/pmprorh_frontend.css
@@ -35,3 +35,27 @@ form.pmpro_form .pmpro_member_profile_edit-fields div.pmpro_checkout-field-selec
 	min-height: 80px;
 	min-width: 200px;
 }
+form.pmpro_form .pmpro_member_profile_edit-fields div.pmprorh_file_preview {
+	display: block;
+	margin: 1em 0 0 0;
+}
+div.pmprorh_file_preview img {
+	max-height: 150px;
+	max-width: 150px;
+}
+button.pmprorh_delete_restore_file,
+button.pmprorh_delete_restore_file:hover {
+	margin: 0;
+	padding: 0;
+	box-shadow: initial;
+	border: initial;
+	border-radius: initial;
+	background: initial;
+	font-size: initial;
+	transform: initial;
+	cursor: initial;
+	text-align: initial;
+	color: initial;
+	text-decoration: underline;
+}
+

--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -818,11 +818,11 @@ function pmprorh_rf_show_extra_frontend_profile_fields( $user, $withlocations = 
 					<h3><?php echo $box->label; ?></h3>
 				<?php } ?>
 
-				<?php if ( ! empty( $box->description ) ) { ?>
-					<div class="pmpro_checkout_decription"><?php echo $box->description; ?></div>
-				<?php } ?>
-
 				<div class="pmpro_member_profile_edit-fields">
+					<?php if ( ! empty( $box->description ) ) { ?>
+						<div class="pmpro_checkout_description"><?php echo $box->description; ?></div>
+					<?php } ?>
+
 					<?php
 						 // Cycle through groups.
 						foreach( $fields as $field ) {

--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -213,6 +213,14 @@ function pmprorh_scripts()
 }
 add_action( 'wp_enqueue_scripts', 'pmprorh_scripts' );
 
+/**
+ * Enqueue admin CSS
+ */
+function pmprorh_admin_enqueue_scripts() {
+	wp_enqueue_style('pmprorh_admin', PMPRORH_URL . '/css/pmprorh_admin.css', array(), PMPRORH_VERSION, "screen");
+}
+add_action( 'admin_enqueue_scripts', 'pmprorh_admin_enqueue_scripts' );
+
 /*
 	Cycle through extra fields. Show them at checkout.
 */

--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -818,6 +818,10 @@ function pmprorh_rf_show_extra_frontend_profile_fields( $user, $withlocations = 
 					<h3><?php echo $box->label; ?></h3>
 				<?php } ?>
 
+				<?php if ( ! empty( $box->description ) ) { ?>
+					<div class="pmpro_checkout_decription"><?php echo $box->description; ?></div>
+				<?php } ?>
+
 				<div class="pmpro_member_profile_edit-fields">
 					<?php
 						 // Cycle through groups.


### PR DESCRIPTION
Support for core user fields stored in the users table in Register Helper. Primarily set up to support a Register Helper field for user_url, but can be extended (but not recommended) using the pmprorh_user_table_fields filter.

`function add_nickname_and_display_name_pmprorh_user_table_fields( $user_table_fields ) {
	
	// Set the return value to an array if it is not one.
	if ( ! is_array( $user_table_fields ) ) {
		$user_table_fields = array();
	}

	// Add nicename as a new field.
	$user_table_fields[] = 'user_nicename';
	$user_table_fields[] = 'display_name';

	return $user_table_fields;	
}
add_filter( 'pmprorh_user_table_fields', 'add_nickname_and_display_name_pmprorh_user_table_fields' );`

The "description" attribute of the `pmprorh_add_checkout_box` was not displaying in the frontend member profile edit page. This PR adds that attribute to display below the checkout box title on the frontend profile page.

First movement toward file preview and file deletion. Note that checkout has an error with this current version - we should revise the script tag on lines 653-665 to only include on the profile editing page.