### PR TITLE
Add .pmpro-required to field parent div

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -776,6 +776,7 @@
 			// add default pmpro-required class to field.
 			if ( ! empty( $this->required ) ) {
 				$this->class .= " pmpro-required";
+				$this->divclass .= " pmpro-required";
 			}
 			
 			$this->divclass .= " pmpro_checkout-field-" . $this->type;


### PR DESCRIPTION
Seems that the intention was there but .pmpro-required was only added
to the input, not the parent div. I chose to keep $this->class separate
from $this->divclass for future flexibility