### PR TITLE
Require only if shown

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -924,7 +924,9 @@
 								}
 							} else {
 								// Single checkbox that is unchecked. Set to show field only if checkbox is checked.
-								return empty( $check['value'] );
+								if ( ! empty( $check['value'] ) ) {
+									return false;
+								}
 							}
 						} elseif ( isset( $_REQUEST[ $check['id'] ] ) && $check['value'] != $_REQUEST[ $check['id'] ] ) {
 							// This fields depends on another field type.

--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -635,8 +635,7 @@ function pmprorh_rf_pmpro_registration_checks($okay)
 				else
 					$value = false;
 
-				if(!empty($field->required) && empty( $_REQUEST[$field->name] ) && empty( $_FILES[$field->name]['name'] ) && empty( $_REQUEST[$field->name.'_old'] ) )
-				{
+				if( ! $field->was_filled_if_needed() ) {
 					$required[] = $field->name;
                     $required_labels[] = $field->label;
 				}


### PR DESCRIPTION
Required fields are now only enforced if they are being shown on the checkout page, meaning that they are not hidden by a `depends` field and are not a part of a checkout box only shown to new users when a user is currently logged in.

Resolves #70 
