### PR TITLE
Make the dependsOn condition a AND or OR

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -21,6 +21,7 @@
 			$this->memberslistcsv = false;
 			$this->readonly = false;
 			$this->depends = array();
+			$this->dependsOr = false;
 			$this->showrequired = true;
 			$this->showmainlabel = true;
 			$this->divclass = null;
@@ -803,7 +804,7 @@
 					function pmprorh_<?php echo $this->id;?>_hideshow()
 					{						
 						if(
-							<?php echo implode(" && ", $checks); ?>
+							<?php echo implode(($this->dependsOr ? " || " : " && "), $checks); ?>
 						)
 						{
 							jQuery('#<?php echo $this->id;?>_tr').show();


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds the possibility to use the depends attribute if there are more dependencies defined in either the AND validation (default) or the OR validation (any statement should be true).

### How to test the changes in this Pull Request:

1. Create a conditional element with multiple conditions.
2. Set the `dependsOr` attribute to `true`
3. Trigger the different conditions

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dependencies for an element now support OR validations
