### PR TITLE
Fix mixed content errors in wp-admin when using HTTPS.

### DIFF
--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -217,7 +217,15 @@ add_action( 'wp_enqueue_scripts', 'pmprorh_scripts' );
  * Enqueue admin CSS
  */
 function pmprorh_admin_enqueue_scripts() {
-	wp_enqueue_style('pmprorh_admin', PMPRORH_URL . '/css/pmprorh_admin.css', array(), PMPRORH_VERSION, "screen");
+	wp_enqueue_style(
+		'pmprorh_admin',
+		function_exists( 'pmpro_https_filter' )
+			? pmpro_https_filter( PMPRORH_URL ) . '/css/pmprorh_admin.css'
+			: PMPRORH_URL . '/css/pmprorh_admin.css',
+		array(),
+		PMPRORH_VERSION,
+		'screen'
+	);
 }
 add_action( 'admin_enqueue_scripts', 'pmprorh_admin_enqueue_scripts' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When using HTTPS, this error appears in the JS dev console on `wp-admin` pages:

> Mixed Content: The page at 'https://SITE_DOMAIN/wp-admin/plugins.php' was loaded over HTTPS, but requested an insecure stylesheet 'http://SITE_DOMAIN/wp-content/plugins/pmpro-register-helper/css/pmprorh_admin.css?ver=1.7'. This request has been blocked; the content must be served over HTTPS.

This PR fixes that issue.

### How to test the changes in this Pull Request:

1. Install this plugin (and PMPro, of course)
2. View any `wp-admin` page, e.g. `plugins.php`.
3. Open the dev console and ensure the Mixed Content message doesn't appear.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed mixed content errors on admin pages when using HTTPS.
