### PR TITLE
Sanitize uploaded file name

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -277,7 +277,7 @@
 			}
 			
 			//figure out new filename
-			$filename = $file['name'];
+			$filename = sanitize_file_name($file['name']);
 			$count = 0;
 						
 			while(file_exists($pmprorh_dir . $filename))


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We have users who love to upload file names like `EIN #.pdf` which is inaccessible to our admins when they review documents. It's a pain to manually rename these documents and update the database. This PR uses the WordPress function `sanitize_file_name()` to strip invalid characters when files are uploaded.

### How to test the changes in this Pull Request:

1. Upload a file name with an invalid character ([#, etc](https://developer.wordpress.org/reference/functions/sanitize_file_name/#source))
2. Verify that it was renamed appropriately.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Sanitize uploaded file names to avoid invalid file names.