### PR TITLE
Fix: Set number field value if value is 0 (zero)

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -386,6 +386,9 @@
 			}
 			elseif($this->type == "number")
 			{
+				if ( strlen($value) === 0 && isset( $this->value ) && strlen($this->value) > 0 && is_numeric( $this->value ) ) {
+					$value = esc_attr( $this->value );
+				}
 				$r = '<input type="number"  min="0" step="1" pattern="\d+" id="' . $this->id . '" name="' . $this->name . '" value="' . esc_attr($value) . '" ';
 				if(!empty($this->size))
 					$r .= 'size="' . $this->size . '" ';


### PR DESCRIPTION
Accept `0` (zero) as a value set for a number field's `value` option.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Added additional logic to check  if a value was set and is numeric to allow a default value of `0`

Resolves https://github.com/strangerstudios/pmpro-register-helper/issues/226

### How to test the changes in this Pull Request:

1. Create a code snippet for the site that creates a number field and set the `value` option for the field to `0`

```php
$fields[] = new PMProRH_Field(
		'test_value_zero', // input field name, used as meta key
		'number',         // field type
		array(
			'label'           => 'Number Test', // display custom label, if not used field name will be used
			'value'           => '0',
			'hint'            => 'Testing 0 (zero) as the default value', // display a hint under field
			'profile'         => true, // show on profile
		)
	);
```

2. Navigate to the Membership Checkout page on the frontend.
3. Inspect rendered HTML for the number field to confirm the value is set as `0`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

BUGFIX/ENHANCEMENT: Accept 0 (zero) as the default value displayed for a number field.
