### PR TITLE
Accept custom min and step attributes for Number field type.

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -386,16 +386,29 @@
 			}
 			elseif($this->type == "number")
 			{
-				$r = '<input type="number"  min="0" step="1" pattern="\d+" id="' . $this->id . '" name="' . $this->name . '" value="' . esc_attr($value) . '" ';
+				$r = '<input type="number" pattern="\d+" id="' . $this->id . '" name="' . $this->name . '" value="' . esc_attr($value) . '" ';
 				if(!empty($this->size))
 					$r .= 'size="' . $this->size . '" ';
 				if(!empty($this->class))
 					$r .= 'class="' . $this->class . '" ';
 				if(!empty($this->readonly))
 					$r .= 'readonly="readonly" ';
-				if(!empty($this->html_attributes))
+				if ( ! empty( $this->html_attributes ) ) {
+					// If custom values not available set the defaults
+					if ( ! array_key_exists( 'min', $this->html_attributes ) ) {
+						$this->html_attributes['min'] = '0';
+					}
+					if ( ! array_key_exists( 'step', $this->html_attributes ) ) {
+						$this->html_attributes['step'] = '1';
+					}
 					$r .= $this->getHTMLAttributes();
-				$r .= ' />';				
+				} else {
+					// Set the defaults
+					$this->html_attributes['min'] = '0';
+					$this->html_attributes['step'] = '1';
+					$r .= $this->getHTMLAttributes();
+				}
+				$r .= ' />';
 			}
 			elseif($this->type == "password")
 			{


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Remove the hardcoded default `min` and `step` attributes set and add them as `html_attributes`.

Resolves https://github.com/strangerstudios/pmpro-register-helper/issues/227

### How to test the changes in this Pull Request:

1. Create a code snippet for the site that creates a number field and add `min` and `step` to the `html_attributes` option.

```php
$fields[] = new PMProRH_Field(
	'test_number_min_step', // input field name, used as meta key
	'number',         // field type
	array(
		'label'           => 'Number Test', // display custom label, if not used field name will be used
		'html_attributes' => array(
			'min'  => '5',
			'step' => '5',
		), // add valid html input field attributes
		'hint'            => 'This is a test of html attributes for a number field', // display a hint under field
		'profile'         => true, // show on profile
	)
);
```

2. Navigate to the Membership Checkout page on the frontend.
3. Inspect rendered HTML for the number field.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

BUGFIX/ENHANCEMENT: Accept custom "step" and "min" HTML attributes set in the "html_attributes" option.
