### PR TITLE
Include order object as hook param

### DIFF
--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -542,10 +542,10 @@ function pmprorh_pmpro_after_checkout( $user_id, $morder )
 	}
 }
 add_action( 'pmpro_after_checkout', 'pmprorh_pmpro_after_checkout', 10, 2 );
-add_action('pmpro_before_send_to_paypal_standard', 'pmprorh_pmpro_after_checkout');	//for paypal standard we need to do this just before sending the user to paypal
-add_action('pmpro_before_send_to_twocheckout', 'pmprorh_pmpro_after_checkout', 20);	//for 2checkout we need to do this just before sending the user to 2checkout
-add_action('pmpro_before_send_to_gourl', 'pmprorh_pmpro_after_checkout', 20);	//for the GoURL Bitcoin Gateway Add On
-add_action('pmpro_before_send_to_payfast', 'pmprorh_pmpro_after_checkout', 20);	//for the Payfast Gateway Add On
+add_action('pmpro_before_send_to_paypal_standard', 'pmprorh_pmpro_after_checkout', 20, 2);	//for paypal standard we need to do this just before sending the user to paypal
+add_action('pmpro_before_send_to_twocheckout', 'pmprorh_pmpro_after_checkout', 20, 2);	//for 2checkout we need to do this just before sending the user to 2checkout
+add_action('pmpro_before_send_to_gourl', 'pmprorh_pmpro_after_checkout', 20, 2);	//for the GoURL Bitcoin Gateway Add On
+add_action('pmpro_before_send_to_payfast', 'pmprorh_pmpro_after_checkout', 20, 2);	//for the Payfast Gateway Add On
 
 /**
  * Sanitizes the passed value.

--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -457,7 +457,7 @@ add_action("pmpro_checkout_before_submit_button", "pmprorh_pmpro_checkout_before
 /*
 	Update the fields at checkout.
 */
-function pmprorh_pmpro_after_checkout($user_id)
+function pmprorh_pmpro_after_checkout( $user_id, $morder )
 {
 	global $pmprorh_registration_fields;
 
@@ -533,7 +533,7 @@ function pmprorh_pmpro_after_checkout($user_id)
 
 					//callback?
 					if(!empty($field->save_function))
-						call_user_func($field->save_function, $user_id, $field->name, $value);
+						call_user_func( $field->save_function, $user_id, $field->name, $value, $morder );
 					else
 						update_user_meta($user_id, $field->meta_key, $value);
 				}
@@ -541,7 +541,7 @@ function pmprorh_pmpro_after_checkout($user_id)
 		}
 	}
 }
-add_action('pmpro_after_checkout', 'pmprorh_pmpro_after_checkout');
+add_action( 'pmpro_after_checkout', 'pmprorh_pmpro_after_checkout', 10, 2 );
 add_action('pmpro_before_send_to_paypal_standard', 'pmprorh_pmpro_after_checkout');	//for paypal standard we need to do this just before sending the user to paypal
 add_action('pmpro_before_send_to_twocheckout', 'pmprorh_pmpro_after_checkout', 20);	//for 2checkout we need to do this just before sending the user to 2checkout
 add_action('pmpro_before_send_to_gourl', 'pmprorh_pmpro_after_checkout', 20);	//for the GoURL Bitcoin Gateway Add On


### PR DESCRIPTION
The `pmpro_after_checkout` hook had `$morder` (order object) as a parmater since PMPro v2.0.
Added this parameter to allow the custom save_function to be able to obtain order details.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Use case scenario: Collect custom registration field at checkout using a custom callback function to save field value to `{prefix}_pmpro_membership_ordermeta` table.

### How to test the changes in this Pull Request:

1. Create RH field with custom `save_function` callback that saves field value to the order meta table.
2. Check out for a level that displays this field.
3. Check `{prefix}_pmpro_membership_ordermeta` table that value was captured as meta.

```PHP
function my_default_wp_user_checkout_fields() {
	// don't break if Register Helper is not loaded
	if ( ! function_exists( 'pmprorh_add_registration_field' ) ) {
		return false;
	}

	// create array.
	$fields = array();

	// user_url field
	$fields[] = new PMProRH_Field(
		'example_order_meta',
		'text',
		array(
			'label'         => 'Example Order Meta Field', // Change label here
			'required'      => true, // Make field optional (set to true to make required)
			'save_function' => 'my_pmprorh_callback_update_order_meta', // Custom callback to save field values
		)
	);

	foreach ( $fields as $field ) {
		pmprorh_add_registration_field( 'checkout_boxes', $field );
	}

}
add_action( 'init', 'my_default_wp_user_checkout_fields' );

function my_pmprorh_callback_update_order_meta( $user_id, $field_name, $field_value, $morder ) {
	$order_id = intval( $morder->id );
	update_pmpro_membership_order_meta( $order_id, $field_name, $field_value );
}
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ENHANCEMENT: Include order object as parameter for callbacks hooking into `pmpro_after_checkout`
