### PR TITLE
add after_tos_fields location

### DIFF
--- a/pmpro-register-helper.php
+++ b/pmpro-register-helper.php
@@ -437,6 +437,20 @@ function pmprorh_pmpro_checkout_after_billing_fields()
 }
 add_action("pmpro_checkout_after_billing_fields", "pmprorh_pmpro_checkout_after_billing_fields");
 
+// after tos fields
+function pmprorh_pmpro_checkout_after_tos_fields() {
+	global $pmprorh_registration_fields;
+
+	if ( ! empty( $pmprorh_registration_fields['after_tos_fields'] ) ) {
+		foreach ( $pmprorh_registration_fields['after_tos_fields'] as $field ) {
+			if ( is_a( $field, 'PMProRH_Field' ) && pmprorh_checkFieldForLevel( $field ) && ( ! isset( $field->profile ) || $field->profile !== 'only' && $field->profile !== 'only_admin' ) ) {
+				$field->displayAtCheckout();
+			}
+		}
+	}
+}
+add_action( 'pmpro_checkout_after_tos_fields', 'pmprorh_pmpro_checkout_after_tos_fields' );
+
 //before submit button
 function pmprorh_pmpro_checkout_before_submit_button()
 {


### PR DESCRIPTION
Add location `after_tos_fields` that hooks into `pmpro_checkout_after_tos_fields` to allow RH fields to be published in that location.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add a valid location for Register Helper to allow fields to be published in the `pmpro_checkout_after_tos_fields` location on the checkout page.

Resolves [238](https://github.com/strangerstudios/pmpro-register-helper/issues/238)

### How to test the changes in this Pull Request:

1. Add custom code that creates a text field for Register Helper.
2. Set location to `after_tos_fields`, e.g. `pmprorh_add_registration_field( 'after_tos_fields', $field );`
3. Navigate to the checkout page to view field at this location

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement: Add location `after_tos_fields` that hooks into `pmpro_checkout_after_tos_fields` to allow RH fields to be published in that location.