### PR TITLE
Checking if functions and classes already exists to avoid issues if PMPro 2.9 is already loaded.

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! class_exists( 'PMProRH_Field' ) ) {
 	class PMProRH_Field
 	{
 		function __construct($name = NULL, $type = NULL, $attr = NULL)
@@ -1100,3 +1101,4 @@
 			return $filled;
 		}
 	}
+}


### PR DESCRIPTION
### All Submissions:

PMPro 2.9 replaces Register Helper and deactivates it on updating. However, some folks may want to reactivate Register Helper for some reason or at least don't want to encounter a fatal error when trying.

This update uses function_exists and class_exists checks to prevent these errors.

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fixed fatal error that would occur if PMPro 2.9+ were already loaded when activating.
