### PR TITLE
Set certain methods to static to avoid PHP8 Errors

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -191,7 +191,7 @@ if ( ! class_exists( 'PMProRH_Field' ) ) {
 		}
 
 		// Save function for users table field.
-		function saveUsersTable( $user_id, $name, $value ) {
+		static function saveUsersTable( $user_id, $name, $value ) {
 			// Special sanitization needed for certain user fields.
 			if ( $name === 'user_url' ) {
 				$value = esc_url_raw( $value );
@@ -205,7 +205,7 @@ if ( ! class_exists( 'PMProRH_Field' ) ) {
 		}
 
 		// Save function for user taxonomy field.
-		function saveTermRelationshipsTable( $user_id, $name, $value ) {			
+		static function saveTermRelationshipsTable( $user_id, $name, $value ) {			
 			// We expect an array below.
 			if ( ! is_array( $value ) ) {
 				$value = array( $value );
@@ -236,7 +236,7 @@ if ( ! class_exists( 'PMProRH_Field' ) ) {
 		}
 
 		//save function for files
-		function saveFile($user_id, $name, $value)
+		static function saveFile($user_id, $name, $value)
 		{			
 			//setup some vars
 			$file = $_FILES[$name];
@@ -403,7 +403,7 @@ if ( ! class_exists( 'PMProRH_Field' ) ) {
 		}
 
         //fix date then update user meta
-        function saveDate($user_id, $name, $value)
+        static function saveDate($user_id, $name, $value)
         {
 	        if ( isset( $this->sanitize ) && true === $this->sanitize ) {
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Sets methods in the Field class to static to prevent errors being thrown in PHP8

### How to test the changes in this Pull Request:

1. Set up Register Helper fields
2. Proceed through the checkout process
3. No errors should be visible or in the error logs

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Ensures that methods in the Field class don't throw errors with PHP8+