### PR TITLE
Fixes an error from the saveDate method

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -405,9 +405,9 @@ if ( ! class_exists( 'PMProRH_Field' ) ) {
         //fix date then update user meta
         function saveDate($user_id, $name, $value)
         {
-	        if ( isset( $this->sanitize ) && true === $this->sanitize ) {
+			if ( null !== ( new PMProRH_Field() )->sanitize && true === ( new PMProRH_Field() )->sanitize ) {
 
-		        $value = pmprorh_sanitize( $value, $this );
+		        $value = pmprorh_sanitize( $value, ( new PMProRH_Field() ) );
 	        }
 
         	$meta_key = str_replace("pmprorhprefix_", "", $name);


### PR DESCRIPTION
An error was being thrown when saving a date due to the method now being static, while it was referencing a non-static method using $this. 

Steps to replicae: 

1. Set up an RH field with a date
2. Save the field/page - no errors should be thrown