### PR TITLE
Revert setting methods to static

### DIFF
--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -191,7 +191,7 @@ if ( ! class_exists( 'PMProRH_Field' ) ) {
 		}
 
 		// Save function for users table field.
-		static function saveUsersTable( $user_id, $name, $value ) {
+		function saveUsersTable( $user_id, $name, $value ) {
 			// Special sanitization needed for certain user fields.
 			if ( $name === 'user_url' ) {
 				$value = esc_url_raw( $value );
@@ -205,7 +205,7 @@ if ( ! class_exists( 'PMProRH_Field' ) ) {
 		}
 
 		// Save function for user taxonomy field.
-		static function saveTermRelationshipsTable( $user_id, $name, $value ) {			
+		function saveTermRelationshipsTable( $user_id, $name, $value ) {			
 			// We expect an array below.
 			if ( ! is_array( $value ) ) {
 				$value = array( $value );
@@ -236,7 +236,7 @@ if ( ! class_exists( 'PMProRH_Field' ) ) {
 		}
 
 		//save function for files
-		static function saveFile($user_id, $name, $value)
+		function saveFile($user_id, $name, $value)
 		{			
 			//setup some vars
 			$file = $_FILES[$name];
@@ -403,7 +403,7 @@ if ( ! class_exists( 'PMProRH_Field' ) ) {
 		}
 
         //fix date then update user meta
-        static function saveDate($user_id, $name, $value)
+        function saveDate($user_id, $name, $value)
         {
 	        if ( isset( $this->sanitize ) && true === $this->sanitize ) {
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
We changed these methods to static due to an error message reported by a customer, but after further review, the error appears to have been a site-specific issue.

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
